### PR TITLE
Fix farm field in admin panel

### DIFF
--- a/sau/admin.py
+++ b/sau/admin.py
@@ -13,23 +13,51 @@ class FarmAwareModelAdmin(admin.ModelAdmin):
         return qs.filter(farm__farmers__in=[request.user])
 
 
-# To get gender-aware dropdown list for parent of a sheep
-class SheepParentForm(FarmAwareModelAdmin):
-    def formfield_for_foreignkey(self, db_field, request, **kwargs):
+class SheepForm(FarmAwareModelAdmin):
+    """Sheep form, for overriding various fields in admin panel.
+
+    Today we override:
+       * father and mother --- make them gender aware
+       * farm --- make field (super)user aware
+    """
+
+    # To get gender-aware dropdown list for parent of a sheep
+    def sheep_parent_filter(self, db_field, request, **kwargs):
         filters = {}
-        if not request.user.is_superuser:
-            filters['farm__farmers__in'] = [request.user]
         if db_field.name == 'father':
             filters['sex'] = 'm'  # male
         elif db_field.name == 'mother':
             filters['sex'] = 'f'  # female
+        else:
+            raise RuntimeError(
+                'Filter called on wrong field: %s' % str(db_field.name))
         kwargs['queryset'] = Sheep.objects.filter(**filters)
-        return super(SheepParentForm, self).formfield_for_foreignkey(db_field,
-                                                                     request,
-                                                                     **kwargs)
+        return super(SheepForm, self).formfield_for_foreignkey(
+            db_field, request, **kwargs)
+
+    # To get user-aware dropdown list for farm of a sheep
+    def farm_filter(self, db_field, request, **kwargs):
+        filters = {}
+        if not request.user.is_superuser:
+            filters['farm__farmers__in'] = [request.user]
+        kwargs['queryset'] = Farm.objects.filter(**filters)
+        return super(SheepForm, self).formfield_for_foreignkey(
+            db_field, request, **kwargs)
+
+    # this is the method we're overriding, but only on fields
+    # * mother/father
+    # * farm
+    def formfield_for_foreignkey(self, db_field, request, **kwargs):
+        if db_field.name in ('father', 'mother'):
+            return self.sheep_parent_filter(db_field, request, **kwargs)
+
+        if db_field.name == 'farm':
+            return self.farm_filter(db_field, request, **kwargs)
+        return super(SheepForm, self).formfield_for_foreignkey(
+            db_field, request, **kwargs)
 
 
-admin.site.register(Sheep, SheepParentForm)
+admin.site.register(Sheep, SheepForm)
 admin.site.register(Medicine)
 admin.site.register(Dose)
 admin.site.register(Farm, FarmAwareModelAdmin)

--- a/sau/views.py
+++ b/sau/views.py
@@ -32,7 +32,7 @@ SAUS = [
 
 
 def __init():
-    f = Farm.objects.create(name='Drange Gård')
+    f = Farm.objects.all()[0]
     f.save()
     for sau in SAUS:
         s = Sheep.objects.create(**sau, farm=f)


### PR DESCRIPTION
Fixes bug where Farm dropdown was a list of sheep.

Solution was to not return `Sheep.objects.filter` when the field was of farm type.