### PR TITLE
Add responsive class for main table

### DIFF
--- a/sau/static/css/sau.css
+++ b/sau/static/css/sau.css
@@ -227,3 +227,31 @@ a {
     text-transform: uppercase;
     font-size: 0.9em;
 }
+
+/*
+  Pure CSS Responsive Table.
+  A Pen By Andor Nagy
+*/
+table.responsive {
+    width: 100%;
+    border-collapse: collapse;
+    margin:50px auto;
+}
+
+/* Zebra striping */
+table.responsive tr:nth-of-type(odd) {
+    background: #eee;
+}
+
+table.responsive th {
+    background: #3498db;
+    color: white;
+    font-weight: bold;
+}
+
+table.responsive td, table.responsive th {
+    padding: 10px;
+    border: 1px solid #ccc;
+    text-align: left;
+    font-size: 18px;
+}

--- a/sau/templates/index.html
+++ b/sau/templates/index.html
@@ -25,7 +25,7 @@
     {% endblock %}
     <div class="content">
       {% block content %}
-      <table class="pure-table">
+      <table class="pure-table responsive">
         <thead>
           <tr>
             <th>&Oslash;re</th>


### PR DESCRIPTION
Don't know if this is correct, but table wasn't full width.

Added class `table.responsive` and made it `width: 100%`.