### PR TITLE
Replace javascript with matplotlib and SVG

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
+numpy
+matplotlib
 dj-database-url>=0.4.1
 Django>=2.0
 gunicorn>=19.6.0

--- a/sau/statistics.py
+++ b/sau/statistics.py
@@ -1,24 +1,72 @@
+from collections import namedtuple
+from io import StringIO
+
+# BE CAREFUL WHAT YOU IMPORT ABOVE matplotlib.use('Agg')
+import matplotlib
+# Force matplotlib to not use any Xwindows backend.
+matplotlib.use('Agg')
+
+import numpy as np
+import matplotlib.pyplot as plt
+
 from sau.models import QUALITIES
 from datetime import datetime as dt
 
+stats = namedtuple(
+    'stats',
+    ['body_count', 'weight_min', 'weight_max', 'weight_avg', 'weight_std'])
+plots = namedtuple('plots', ['quality', 'weight', 'lpy'])
+
+_SVG_ARGS = """
+viewBox="0 0 460 345"
+preserveAspectRatio="xMidYMin slice"
+style="width: 150%;"
+"""
+
+
+def __post_process_svg(svg):
+    start = svg.index('<svg ')
+    stop = svg.index('>', start)
+    svg = svg[:start] + svg[stop:]
+    svg = svg[:start] + '<svg %s' % _SVG_ARGS + svg[start:]
+    return svg
+
+
+def _svg(data, labels):
+    arr = np.array(data)
+    fig, ax = plt.subplots()
+
+    plt.bar(np.arange(len(data)), data, tick_label=list(map(str, labels)))
+
+    imgdata = StringIO()
+    fig.savefig(imgdata, format='svg')
+    imgdata.seek(0)  # rewind the data
+    svg_data = imgdata.read()
+    imgdata.close()
+    plt.close(fig)
+    del imgdata  # Before deleting these lines, recall
+    del fig      # Chesterton's fence
+    return __post_process_svg(svg_data)
+
+
 def _lambs_per_year(sheeps):
     if not sheeps:
-        return [], []
+        return None
     current_year = dt.now().year
     start_year = min([s.birth_date_utc.year for s in sheeps])
 
-    year_labels = list(range(start_year, current_year+1))
+    year_labels = list(range(start_year, current_year + 1))
     year_lst = [0] * len(year_labels)
     for s in sheeps:
         y = s.birth_date_utc.year
         idx = year_labels.index(y)
         year_lst[idx] += 1
-    return year_lst, year_labels
+    return _svg(year_lst, year_labels)
 
 
 def _weights(sheeps):
     if not sheeps:
-        return [], []
+        return None
     weights = [s.weight for s in sheeps if s.weight]
     upper = max(weights)
     weight_labels = list(range(0, int(upper + 2), 200))
@@ -27,12 +75,12 @@ def _weights(sheeps):
         for sw in weights:
             if w < sw <= w + 200:
                 weight_lst[i] += 1
-    return weight_lst, weight_labels
+    return _svg(weight_lst, weight_labels)
 
 
 def _qualities(sheeps):
     if not sheeps:
-        return [], []
+        return None
     qualities = [s.quality for s in sheeps if s.quality]
     quality_lst = []
     quality_labels = []
@@ -40,7 +88,20 @@ def _qualities(sheeps):
         # Q = ('e', 'E')
         quality_lst.append(qualities.count(Q[0]))
         quality_labels.append(Q[1])
-    return quality_lst, quality_labels
+    return _svg(quality_lst, quality_labels)
+
+
+def get_statplots(dead_sheeps, all_sheeps):
+    """Return qualities_count/quality_labels, weight_count/weight_labels for use in
+    barchart.
+
+    """
+
+    qsvg = _qualities(dead_sheeps)
+    wsvg = _weights(dead_sheeps)
+    lpysvg = _lambs_per_year(all_sheeps)
+
+    return plots(quality=qsvg, weight=wsvg, lpy=lpysvg)
 
 
 def get_statistics(dead_sheeps, all_sheeps):
@@ -48,10 +109,21 @@ def get_statistics(dead_sheeps, all_sheeps):
     barchart.
 
     """
+    stat = {
+        'body_count': 0,
+        'weight_min': 0,
+        'weight_max': 0,
+        'weight_avg': 0,
+        'weight_std': 0,
+    }
 
-    quality_lst, quality_labels = _qualities(dead_sheeps)
-    weight_lst, weight_labels = _weights(dead_sheeps)
-    lambyear_lst, lambyear_labels = _lambs_per_year(all_sheeps)
+    to_whole = lambda x: '%d' % int(x)
 
-    return (quality_lst, quality_labels, weight_lst, weight_labels,
-            lambyear_lst, lambyear_labels)
+    if dead_sheeps:
+        arr = np.array([s.weight for s in dead_sheeps])
+        stat['body_count'] = len(arr)
+        stat['weight_min'] = to_whole(arr.min())
+        stat['weight_max'] = to_whole(arr.max())
+        stat['weight_avg'] = to_whole(arr.mean())
+        stat['weight_std'] = to_whole(arr.std())
+    return stats(**stat)

--- a/sau/templates/genealogy.html
+++ b/sau/templates/genealogy.html
@@ -3,12 +3,22 @@
 {% block breadcrumb %}
 <li>
   <span>
+    Sau
+  </span>
+</li>
+<li>
+  <span>
+    {% include "sheep_link.html" with tree="no" %}
+  </span>
+</li>
+<li>
+  <span>
     Tree
   </span>
 </li>
 <li>
   <span>
-    {% include "sheep_link.html" with sheep=sheep %}
+    {% include "sheep_link.html" with tree="only" %}
   </span>
 </li>
 {% endblock %}

--- a/sau/templates/genealogy.html
+++ b/sau/templates/genealogy.html
@@ -25,8 +25,8 @@
 
 <h3>Summary</h3>
 <div style="width: 50%">
-  {% if number_dead %}
-  {% include "statistics.html" with number_dead=number_dead qualities=qualities %}
+  {% if stats.body_count %}
+  {% include "statistics.html" %}
   {% else %}
   No dead children.
   {% endif %}
@@ -44,7 +44,7 @@
   <tbody class="dead_sheep">
     {% include "sheep_row.html" with sheep=prod_children %}
   </tbody>
-  {% if dead_sheep %}
+  {% if dead_children %}
   <tr><td colspan=2> out of production </td></tr>
   <tbody class="dead_sheep">
     {% include "sheep_row.html" with sheep=dead_children %}

--- a/sau/templates/sheep_link.html
+++ b/sau/templates/sheep_link.html
@@ -1,6 +1,10 @@
 {% if sheep %}
+{% if tree != "only" %}
 <a href="{% url 'sau' sheep.slug %}">{{sheep.name}}</a>
+{% endif %}
+{% if tree != "no" %}
 <a href="{% url 'tree' sheep.slug %}">(↗)</a>
+{% endif %}
 {% else %}
 N/A
 {% endif %}

--- a/sau/templates/statistics.html
+++ b/sau/templates/statistics.html
@@ -1,126 +1,23 @@
 {% load staticfiles %}
 
 <ul>
-  <li>Dead children: {{ number_dead }}</li>
-  <li>LPY: {{ lamb_per_year_lst }}</li>
-  <li>Qualities: {{ qualities }}</li>
-  <li>Weights: {{ weights }}</li>
+  <li>Dead children: {{ stats.body_count }}</li>
+  <li>Weight stats:
+    <ul>
+      <li>min = {{ stats.weight_min }}</li>
+      <li>avg = {{ stats.weight_avg }}</li>
+      <li>max = {{ stats.weight_max }}</li>
+      <li>std = {{ stats.weight_std }}</li>
+    </ul>
 </ul>
 
 <script src="{% static "js/Chart.bundle.min.js" %}"></script>
 
 <h3>Lambs per year</h3>
-<div class="canvas-container">
-  <canvas id="lpycanvas"></canvas>
-</div>
+{{svgs.lpy|safe}}
 
 <h3>Qualities</h3>
-<div class="canvas-container">
-  <canvas id="qualitiescanvas"></canvas>
-</div>
+{{svgs.quality|safe}}
 
 <h3>Weights</h3>
-<div class="canvas-container">
-  <canvas id="weightscanvas"></canvas>
-</div>
-
-
-<script>
-    var lpy_data = [];
-    var lpy_labels = [];
-    {% for lpy in lamb_per_year_lst %}
-    lpy_data.push( {{lpy}} );
-    {% endfor %}
-    {% for lpy_lab in lamb_per_year_labels %}
-    lpy_labels.push( "{{lpy_lab}}" );
-    {% endfor %}
-
-    var weight_data = [];
-    var weight_labels = [];
-    {% for w in weights %}
-    weight_data.push( {{w}} );
-    {% endfor %}
-    {% for wl in weight_labels %}
-    weight_labels.push( "{{wl}}" );
-    {% endfor %}
-
-    var quality_data = [];
-    var quality_labels = [];
-    {% for q in qualities %}
-    quality_data.push( {{q}} );
-    {% endfor %}
-    {% for ql in quality_labels %}
-    quality_labels.push( "{{ql}}" );
-    {% endfor %}
-
-    window.onload = function() {
-        var qctx = document.getElementById("qualitiescanvas").getContext("2d");
-        window.myBar = new Chart(qctx, {
-            type: 'bar',
-            data: {
-                labels: quality_labels,
-                datasets: [{data: quality_data}],
-            },
-            options: {
-                responsive: true,
-                legend: {
-                    display: false,
-                },
-                scales: {
-                    yAxes: [{
-                        ticks: {
-                            min: 0,
-                            stepSize: 1
-                        }
-                    }]
-                }
-            }
-        });
-        var wctx = document.getElementById("weightscanvas").getContext("2d");
-        window.myBar = new Chart(wctx, {
-            type: 'bar',
-            data: {
-                labels: weight_labels,
-                datasets: [{data: weight_data}],
-            },
-            options: {
-                responsive: true,
-                legend: {
-                    display: false,
-                },
-                scales: {
-                    yAxes: [{
-                        ticks: {
-                            min: 0,
-                            stepSize: 1
-                        }
-                    }]
-                }
-            }
-        });
-
-        var lpyctx = document.getElementById("lpycanvas").getContext("2d");
-        window.myBar = new Chart(lpyctx, {
-            type: 'bar',
-            data: {
-                labels: lpy_labels,
-                datasets: [{data: lpy_data}],
-            },
-            options: {
-                responsive: true,
-                legend: {
-                    display: false,
-                },
-                scales: {
-                    yAxes: [{
-                        ticks: {
-                            min: 0,
-                            stepSize: 1
-                        }
-                    }]
-                }
-            }
-        });
-
-    };
-</script>
+{{svgs.weight|safe}}


### PR DESCRIPTION
Using `matplotlib`, `numpy` and `io.StringIO`, we can get rid of js-plotting.